### PR TITLE
fix loose metadata when retrieve from Chroma

### DIFF
--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -184,16 +184,15 @@ export class Chroma extends VectorStore {
 
     const results: [Document, number][] = [];
     for (let i = 0; i < firstIds.length; i += 1) {
-      let metadata: Document["metadata"] = {};
-      const storedMetadata = firstMetadatas?.[i];
+      let metadata: Document["metadata"] = firstMetadatas?.[i] ?? {};
 
-      if (storedMetadata && storedMetadata.locFrom && storedMetadata.locTo) {
+      if (metadata.locFrom && metadata.locTo) {
         metadata = {
-          ...firstMetadatas[i],
+          ...metadata,
           loc: {
             lines: {
-              from: storedMetadata.locFrom,
-              to: storedMetadata.locTo,
+              from: metadata.locFrom,
+              to: metadata.locTo,
             },
           },
         };


### PR DESCRIPTION
metadata was lost if no line-of-code keys present

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)